### PR TITLE
use bundle option for pjproject and jansson

### DIFF
--- a/install_freepbx.sh
+++ b/install_freepbx.sh
@@ -52,7 +52,7 @@ tar xvfz asterisk-13-current.tar.gz
 rm -f asterisk-13-current.tar.gz
 cd asterisk-*
 contrib/scripts/install_prereq install
-./configure --libdir=/usr/lib64
+./configure --libdir=/usr/lib64 --with-pjproject-bundled --with-jansson-bundled
 contrib/scripts/get_mp3_source.sh
 make menuselect
 


### PR DESCRIPTION
I noticed an issue when running the script it appears  it is because asterisk-13-current.tar.gz can be any 13.x.x version tag. It seems that if you bundle pjproject and jansson the issue is resolved. i have added bundle option to the configuration to get around this issue in my fork.

let me know if you have any queries.

thanks