### PR TITLE
Update install_freepbx.sh

### DIFF
--- a/install_freepbx.sh
+++ b/install_freepbx.sh
@@ -55,6 +55,7 @@ contrib/scripts/install_prereq install
 ./configure --libdir=/usr/lib64
 contrib/scripts/get_mp3_source.sh
 make menuselect
+./configure --with-pjproject-bundled
 
 make
 make install


### PR DESCRIPTION
Fixed an error when script compiles Asterisk v13.8.x. Previously, it would error out and prevent the compilation and installation from continuing.